### PR TITLE
Better handling of xlims for plotting NLSE results

### DIFF
--- a/examples/NLSE_dudley.py
+++ b/examples/NLSE_dudley.py
@@ -4,18 +4,18 @@ import laserfun as lf
 import numpy as np
 import matplotlib.pyplot as plt
 
-p = lf.Pulse(pulse_type='sech', power=10000, npts=2**13, fwhm_ps=0.0284*1.76, 
+p = lf.Pulse(pulse_type='sech', power=10000, npts=2**13, fwhm_ps=0.0284*1.76,
              center_wavelength_nm=835, time_window_ps=12.5)
 
 # betas = [beta2, beta3, ...] in units [ps^2/m, ps^3/m ...]
 betas = [-11.830e-3, 8.1038e-5, -9.5205e-8, 2.0737e-10,
          -5.3943e-13, 1.3486e-15, -2.5495e-18, 3.0524e-21, -1.7140e-24]
-         
+
 f = lf.Fiber(length=0.15, center_wl_nm=835, dispersion=betas,
              gamma_W_m=0.11)
 
 r = lf.NLSE(p, f, nsaves=200, raman=True)
-z, new_wls, t, AW, AT = r.get_results_wavelength(wmin=400, wmax=1350, wn=400, 
+z, new_wls, t, AW, AT = r.get_results_wavelength(wmin=400, wmax=1350, wn=400,
                                                  datatype='dB')
 
 fig, axs = plt.subplots(1, 2, figsize=(8, 5), tight_layout='True')

--- a/laserfun/__init__.py
+++ b/laserfun/__init__.py
@@ -6,5 +6,6 @@ from . import nlse
 from .fiber import Fiber
 from .pulse import Pulse
 from .nlse import NLSE
+from .nlse import dB
 
 __all__ = [pulse, fiber, nlse, Fiber, Pulse, NLSE]

--- a/laserfun/nlse.py
+++ b/laserfun/nlse.py
@@ -360,9 +360,14 @@ class PulseData:
 
         # Should automate the xlims somehow
         if tlim is None:
-            ax1.set_xlim(-1.5, 1.5)
+            tlim = (-1.5, 1.5)
         if flim is None:
-            ax2.set_xlim(0, 400)
+            flim = (0, 400)
+
+        ax2.set_xlim(flim[0], flim[1])
+
+        ax1.set_xlim(tlim[0], tlim[1])
+
 
         extf = (np.min(self.f), np.max(self.f), np.min(z), np.max(z))
         extt = (np.min(self.t), np.max(self.t), np.min(z), np.max(z))
@@ -378,6 +383,9 @@ class PulseData:
 
         if show:
             plt.show()
+
+        axs = (ax0, ax1, ax2, ax3)
+        return fig, axs
 
 def dB(num):
     with np.errstate(divide='ignore'):


### PR DESCRIPTION
The plotting functions didn't correctly handle the user-selected xlims for the nlse.plot function. Should be fixed now. Also, returns the fig and axs objects so that the user can further change the plot parameters.