### PR TITLE
Dealing with NaN values in dispersion inputs

### DIFF
--- a/examples/NLSE waveguide 0.1.py
+++ b/examples/NLSE waveguide 0.1.py
@@ -36,13 +36,19 @@ neff_int = scipy.interpolate.interp1d(data['widths'], data['neff'], axis=0)
 aeff = aeff_int(width)
 neff = neff_int(width)
 
+# deal with possible nan values in neff and aeff
+wls_n = wls[np.logical_not(np.isnan(neff))]
+neff = neff[np.logical_not(np.isnan(neff))]
+
+wls_a = wls[np.logical_not(np.isnan(aeff))]
+aeff = aeff[np.logical_not(np.isnan(aeff))]
+
 
 def disp_function(z=0):  # provide effective index to the NLSE
-    return (wls, neff)
-
+    return (wls_n, neff)
 
 def gamma_function(z=0):  # provide the nonlinearity at the pump to the NLSE
-    aeff_interp = scipy.interpolate.interp1d(wls, aeff)
+    aeff_interp = scipy.interpolate.interp1d(wls_a, aeff)
     return 2*np.pi*n2/(pulseWL*1e-9*aeff_interp(pulseWL)*1e-12)
 
 

--- a/laserfun/fiber.py
+++ b/laserfun/fiber.py
@@ -77,6 +77,9 @@ class Fiber:
             raise ValueError('D format is not currently supported')
 
         elif dispersion_format == 'n':
+            if np.any(np.isnan(dispersion)):
+                raise ValueError('Dispersion cannot contain NaN values.')
+                
             self.x = dispersion[0]
             self.y = dispersion[1]
 
@@ -158,7 +161,10 @@ class Fiber:
             gamma = self.gamma_function(z)
         else:
             gamma = self.gamma
-
+        
+        if not np.isfinite(gamma):
+            raise ValueError(f'Invalid gamma: {gamma}')
+        
         return gamma
 
     def get_alpha(self, z=0):
@@ -179,6 +185,9 @@ class Fiber:
         else:
             alpha = self.alpha
 
+        if not np.isfinite(alpha):
+            raise ValueError(f'Invalid alpha: {alpha}')
+            
         return alpha
 
     def get_B(self, pulse, z=0):
@@ -248,7 +257,11 @@ class Fiber:
             # interpolate (using a spline) the betas from the refractive index
             # self.x is the wavelength in nm
             # self.y is the refractive index (unitless)
-
+            if not np.all(np.isfinite(self.x)):
+                raise ValueError(f'Invalid wavelength array: {self.x}')
+            if not np.all(np.isfinite(self.y)):
+                raise ValueError(f'Invalid n array: {self.y}')
+            
             supplied_W_THz = 2 * np.pi * 1e-12 * 3e8 / (self.x*1e-9)
             supplied_betas = self.y * 2 * np.pi / (self.x * 1e-9)
 
@@ -268,4 +281,8 @@ class Fiber:
             slope = np.gradient(B)/np.gradient(pulse.w_THz)
             B = B - slope[center_index] * (pulse.v_THz) - B[center_index]
 
+        if not np.all(np.isfinite(B)):
+            raise ValueError(f'Beta array invalid. \
+                             Check dispersion parameters.')
+            
         return B


### PR DESCRIPTION
In response to Issue #68, this deals with nan values in a few places, mainly the dispersion-from-a-file input.

Often our calculated dispersion files have entries that are np.nan. Currently, this causes a mysterious error where the integrator fails. This isn't very helpful. 

So, this PR adds error checking to fiber.py so that the get_B function checks to make sure that the wavelength array and the index array have finite values. Additionally, there is another check such that the final B array is valid, which should cover situations where the dispersion is entered using the beta-expansion method, for example. Additionally, we also check that the gamma and alpha values are finite, since they can probably cause a similar error.

Also, I modified the example file so that it automatically removes nan values from the neff and aeff arrays (and their corresponding wavelengths from the wls arrays). This isn't really necessary for this example, but it may help future users who happen to have nan or inf values in their arrays.