### PR TITLE
simplifying beta2 and beta3 conversion

### DIFF
--- a/examples/NLSE_HNLF.py
+++ b/examples/NLSE_HNLF.py
@@ -60,15 +60,10 @@ level = 0.4  # level relative to maximum to evaluate pulse duration
 
 # ----- END OF PARAMETERS -----
 
-ps_nm_km = -(pulseWL**2) / (2 * np.pi * 2.9979246e5)  # conversion for D2
-ps2_nm2 = pulseWL**4 / (4 * np.pi**2 * 2.9979246e5**2)  # conversion for D3
-ps2_nm = pulseWL**3 / (2 * np.pi**2 * 2.9979246e5**2)
+beta2 = lf.tools.D2_to_beta2(pulseWL, disp)
+beta3 = lf.tools.D3_to_beta3(pulseWL, disp, slope)
 
-# fiber1
-beta2 = disp * ps_nm_km  # (ps^2/km)
-beta3 = slope * ps2_nm2 + disp * ps2_nm  # (ps^3/km)
-
-
+print(beta2, beta3)
 # create the pulse
 pulse_in = lf.Pulse(
     pulse_type="sech",

--- a/examples/NLSE_normal_HNLF_compression.py
+++ b/examples/NLSE_normal_HNLF_compression.py
@@ -19,6 +19,7 @@ FWHM = 0.8  # pulse duration (ps)
 EPP = 300e-12  # Energy per pulse (J)
 
 # Fiber 1:
+fiberWL = 1550  # fiber central wavelength (nm)
 disp1 = -2.4  # fiber dispersion in ps/(nm km)
 slope1 = 0.025  # dispersion slope in ps/(nm^2 km)
 length1 = 5  # length of first fiber in meters
@@ -26,6 +27,7 @@ alpha1 = 0  # loss (dB/cm)
 gamma1 = 10.8  # nonlinearity (1/(W km))
 
 # - second fiber:
+fiberWL2 = 1550  # fiber central wavelength (nm)
 disp2 = 18  # fiber dispersion in ps/(nm km)
 slope2 = 0.025  # dispersion slope in ps/(nm^2 km)
 length2 = 1.8  # length of second fiber in meters
@@ -53,25 +55,13 @@ level = 0.4  # level relative to maximum to evaluate pulse duration
 
 # ----- END OF PARAMETERS -----
 
-ps_nm_km = -(pulseWL**2) / (2 * np.pi * 2.9979246e5)  # conversion for D2
-ps2_nm2 = pulseWL**4 / (4 * np.pi**2 * 2.9979246e5**2)  # conversion for D3
-ps2_nm = pulseWL**3 / (2 * np.pi**2 * 2.9979246e5**2)
-
 # fiber1
-beta2 = disp1 * ps_nm_km  # (ps^2/km)
-beta3 = slope1 * ps2_nm2 + disp1 * ps2_nm  # (ps^3/km)
-
-beta3b = (pulseWL**4/(4*np.pi**2*2.9979246e5**2))*slope1 \
-        - (pulseWL/(np.pi*2.9979246e5))*beta2
-        
-print(beta3, beta3b)
-
-print(beta2, -(pulseWL**2) / (2 * np.pi * 2.9979246e5) * disp1)
-        
+beta2 = lf.tools.D2_to_beta2(fiberWL, disp1)
+beta3 = lf.tools.D3_to_beta3(fiberWL, disp1, slope1)
 
 # fiber 2
-beta22 = disp2 * ps_nm_km  # (ps^2/km)
-beta32 = slope2 * ps2_nm2 + disp2 * ps2_nm  # (ps^3/km)
+beta22 = lf.tools.D2_to_beta2(fiberWL2, disp2)
+beta32 = lf.tools.D3_to_beta3(fiberWL2, disp2, slope2)
 
 # create the pulse
 pulse_in = lf.Pulse(
@@ -89,7 +79,7 @@ pulse_in = lf.Pulse(
 # create the fiber
 fiber1 = lf.Fiber(
     length1,
-    center_wl_nm=pulseWL,
+    center_wl_nm=fiberWL,
     dispersion_format="GVD",
     dispersion=(beta2 * 1e-3, beta3 * 1e-3),
     gamma_W_m=gamma1 * 1e-3,
@@ -117,7 +107,7 @@ pulse1.aw = pulse1.aw * np.sqrt(fraction)
 # create the fiber!
 fiber2 = lf.Fiber(
     length2,
-    center_wl_nm=pulseWL,
+    center_wl_nm=fiberWL2,
     dispersion_format="GVD",
     dispersion=(beta22 * 1e-3, beta32 * 1e-3),
     gamma_W_m=gamma2 * 1e-3,

--- a/laserfun/__init__.py
+++ b/laserfun/__init__.py
@@ -3,9 +3,10 @@
 from . import pulse
 from . import fiber
 from . import nlse
+from . import tools
 from .fiber import Fiber
 from .pulse import Pulse
 from .nlse import NLSE
 from .nlse import dB
 
-__all__ = [pulse, fiber, nlse, Fiber, Pulse, NLSE]
+__all__ = [pulse, fiber, nlse, tools, Fiber, Pulse, NLSE]

--- a/laserfun/fiber.py
+++ b/laserfun/fiber.py
@@ -38,7 +38,7 @@ class Fiber:
             also determines the B values returned by the get_B function.
         dispersion_formats: string
             determines what format the dispersion is given in. Can be
-            'GVD' or 'D' or 'n'
+            'GVD', 'D', or 'n'
             Corresponding to :
             Beta coefficients (GVD, in units of ps^2/m or ps^2/km) or
             D (ps/nm/km)

--- a/laserfun/tests/test_all.py
+++ b/laserfun/tests/test_all.py
@@ -163,6 +163,37 @@ def test_nlse_psd():
 
     # TODO: figure out why the "per nm" tests require higher tolerances
 
+def test_dispersion_tools():
+    """Test dispersion conversion tools."""
+    from laserfun import tools
+    
+    # Test values (approximate)
+    wl = 1550 # nm
+    D = 5 # ps/nm/km [SMF-28]
+    S = 0.025 # ps/nm^2/km
+    
+    # Calculate beta2
+    beta2 = tools.D2_to_beta2(wl, D)
+    
+    # Calculate D back
+    D_calc = tools.beta2_to_D2(wl, beta2)
+    assert np.isclose(D, D_calc), "D -> beta2 -> D failed"
+    
+    # Calculate beta3
+    beta3 = tools.D3_to_beta3(wl, D, S)
+    
+    # Calculate S back
+    S_calc = tools.beta3_to_D3(wl, beta3, D2=D)
+    assert np.isclose(S, S_calc), "S -> beta3 -> S failed"
+
+    # Explicit check for beta2 and beta3 values
+    expected_beta2 = -6.377240954930596
+    expected_beta3 = 0.051164480183629686
+    
+    assert np.isclose(beta2, expected_beta2), f"Expected beta2={expected_beta2}, got {beta2}"
+    assert np.isclose(beta3, expected_beta3), f"Expected beta3={expected_beta3}, got {beta3}"
+
+
 def test_examples():
     sys.path.append(__file__+'../../examples')
     import examples
@@ -181,9 +212,14 @@ if __name__ == '__main__':
     test_fiber()
     print('test_nlse_psd')
     test_nlse_psd()
+    print('test_dispersion_tools...')
+    test_dispersion_tools()
     print('Testing examples...')
-    import sys
-    sys.path.append(__file__+'../../examples')
+    examples_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../examples'))
+    sys.path.append(examples_path)
     import examples
-    print('Tested all examples in: ' + os.path.split(examples.__file__)[0])
+    if hasattr(examples, '__file__') and examples.__file__:
+        print('Tested all examples in: ' + os.path.split(examples.__file__)[0])
+    else:
+        print(f'Tested examples in: {examples_path}')
     print('Tests complete!')

--- a/laserfun/tools.py
+++ b/laserfun/tools.py
@@ -1,0 +1,31 @@
+
+import numpy as np
+
+c_mks = 299792458.0
+c_nmps = c_mks * 1e9 / 1e12
+
+def D2_to_beta2(wavelength_nm, D2):
+    """Convert dispersion parameter D [ps/nm/km] to GVD beta2 [ps^2/km]."""
+    return -(wavelength_nm**2) / (2.0 * np.pi * c_nmps) * D2
+
+def beta2_to_D2(wavelength_nm, beta2):
+    """Convert GVD beta2 [ps^2/km] to dispersion parameter D [ps/nm/km]."""
+    return -(2.0 * np.pi * c_nmps) / (wavelength_nm**2) * beta2
+
+def D3_to_beta3(wavelength_nm, D2, D3):
+    """Convert dispersion D and slope S to TOD beta3 [ps^3/km]."""
+    term_slope = (wavelength_nm**4) / (4.0 * np.pi**2 * c_nmps**2) * D3
+    term_D = (wavelength_nm**3) / (2.0 * np.pi**2 * c_nmps**2) * D2
+    return term_slope + term_D
+
+def beta3_to_D3(wavelength_nm, beta3, D2=None, beta2=None):
+    """Convert TOD beta3 [ps^3/km] to dispersion slope S [ps/nm^2/km].
+    
+    Requires either D2 [ps/nm/km] or beta2 [ps^2/km].
+    """
+    if D2 is None:
+        if beta2 is None:
+            raise ValueError("Provide either D2 or beta2.")
+        D2 = beta2_to_D2(wavelength_nm, beta2)
+
+    return (4.0 * np.pi**2 * c_nmps**2 / wavelength_nm**4) * beta3 - (2.0 / wavelength_nm) * D2


### PR DESCRIPTION
I went ahead and added some functions to a new `lf.tools` file that make the conversion easier. 

This PR introduces a new tools module to properly handle conversions between dispersion parameters ($D$, $S$) and Group Velocity Dispersion coefficients ($\beta_2$, $\beta_3$). It also updates existing examples to use these new tools and improves the test suite.